### PR TITLE
Added cache ability

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -13,7 +13,7 @@ shopt -s extglob
 
 # parse and derive params
 BUILD_DIR=$1
-CACHE_DIR="$2/vendor"
+CACHE_DIR=$2
 LP_DIR=`cd $(dirname $0); cd ..; pwd`
 
 # config
@@ -31,15 +31,17 @@ mkdir -p $VENDOR_DIR
 echo "Vendoring R $R_VERSION" | indent
 
 # Check if we can pull from cache rather than download tar
-if [ "$(cat $CACHE_DIR/R/bin/.version 2>/dev/null)" = "$R_VERSION" ]
+if [ "$(cat $CACHE_DIR/vendor/R/bin/.version 2>/dev/null)" = "$R_VERSION" ]
 then
   echo "Desired R version ($R_VERSION) cached" | indent
   mkdir -p $VENDOR_DIR
-  cp -R $CACHE_DIR/* $VENDOR_DIR
+  shopt -s extglob
+  cp -R $CACHE_DIR/vendor/!(ruby*) $VENDOR_DIR
 else
   # download and unpack binaries
   echo "Downloading and unpacking R binaries" | indent
   mkdir -p $VENDOR_DIR && curl $R_BINARIES -s -o - | tar xzf - -C $VENDOR_DIR
+  echo $R_VERSION > $VENDOR_DIR/R/bin/.version
 fi
 
 mkdir -p /app/vendor
@@ -77,12 +79,18 @@ echo "R $R_VERSION successfully installed" | indent
 rm -rf $VENDOR_DIR && mkdir -p $VENDOR_DIR
 cp -R /app/vendor/* $VENDOR_DIR/
 
+echo "Caching R directories for future builds"
+rm -rf $CACHE_DIR
+rm -r $VENDOR_DIR/bundle $VENDOR_DIR/redis-rb $VENDOR_DIR/ruby-1.9.2 $VENDOR_DIR/heroku
+mkdir -p $CACHE_DIR
+test -d $VENDOR_DIR && cp -r $VENDOR_DIR $CACHE_DIR/
+
 # removed unneeded files to make slug smaller
 pushd $VENDOR_DIR/gcc-4.3 > /dev/null && rm -rf !(lib64) && popd > /dev/null
 pushd $VENDOR_DIR/glibc-2.7 > /dev/null && rm -rf !(string|time) && popd > /dev/null
 
 # HACK
-cp $VENDOR_DIR/gcc-4.3/lib64/* $VENDOR_DIR/R/lib64/R/lib
+cp /app/vendor/gcc-4.3/lib64/* $VENDOR_DIR/R/lib64/R/lib
 
 # Write a sane .Rprofile
 cat > $BUILD_DIR/.Rprofile <<RPROFILE
@@ -90,4 +98,5 @@ r <- getOption("repos");
 r["CRAN"] <- "$CRAN_MIRROR";
 options(repos=r);
 options(bitmapType="cairo")
+options(unzip = "internal")
 RPROFILE


### PR DESCRIPTION
The buildpack was downloading the R binaries and installing all packages with every push to Heroku. Heroku supports caching of binaries and packages. Added this to the buildpack. Now the first push installs R binaries and all packages from scratch. Subsequent pushes will use the binaries and packages in the cache 

Also added "internal" for unzip in the .RPofile options. On most Linux distributions, this is set out of the box. Heroku, for some reason, does not set this. Causes problems installing some packages. Easy fix so made the change.
